### PR TITLE
Fix lint attribute

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@
 //! ```
 
 #![no_std]
-#[warn(missing_docs)]
+#![warn(missing_docs)]
 use core::{
     cmp,
     fmt::{self, Display},


### PR DESCRIPTION
The ! was missing making the lint attribute not work.